### PR TITLE
Add emote picker to battle arena

### DIFF
--- a/lib/api/services/user_service.dart
+++ b/lib/api/services/user_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:cajucards/api/api_client.dart';
+import 'package:cajucards/models/emote.dart';
 import 'package:cajucards/models/player.dart';
 
 class UserService {
@@ -15,6 +16,22 @@ class UserService {
       return Player.fromJson(decoded['data']['user']);
     } else {
       throw Exception('Falha ao carregar o perfil do cajuicer.');
+    }
+  }
+
+  Future<List<Emote>> getUserEmotes() async {
+    final response = await _apiClient.get('/users/me/emotes', requireAuth: true);
+
+    if (response.statusCode == 200) {
+      final decoded = json.decode(response.body);
+      final emotes = decoded['data']['emotes'] as List<dynamic>;
+
+      return emotes
+          .map((emote) => Emote.fromJson(emote as Map<String, dynamic>))
+          .toList();
+    } else {
+      final decoded = json.decode(response.body);
+      throw Exception(decoded['message'] ?? 'Falha ao carregar emotes.');
     }
   }
 

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -21,6 +21,10 @@ class PlayerProvider with ChangeNotifier {
   String? _buyChestError;
   Emote? _lastWonEmote;
 
+  List<Emote> _emotes = [];
+  bool _isLoadingEmotes = false;
+  String? _emotesError;
+
   // 4. Estados para controlar o histórico de partidas
   List<MatchHistoryItem> _matches = [];
   bool _isLoadingHistory = false;
@@ -45,6 +49,10 @@ class PlayerProvider with ChangeNotifier {
   List<MatchHistoryItem> get matches => _matches;
   bool get isLoadingHistory => _isLoadingHistory;
   String? get historyError => _historyError;
+
+  List<Emote> get emotes => _emotes;
+  bool get isLoadingEmotes => _isLoadingEmotes;
+  String? get emotesError => _emotesError;
 
 
   /// Busca os dados do jogador logado.
@@ -116,6 +124,23 @@ class PlayerProvider with ChangeNotifier {
   void clearBuyChestError() {
     _buyChestError = null;
     notifyListeners();
+  }
+
+  Future<void> fetchUserEmotes() async {
+    if (_isLoadingEmotes) return;
+
+    _isLoadingEmotes = true;
+    _emotesError = null;
+    notifyListeners();
+
+    try {
+      _emotes = await _userService.getUserEmotes();
+    } catch (e) {
+      _emotesError = e.toString().replaceFirst("Exception: ", "");
+    } finally {
+      _isLoadingEmotes = false;
+      notifyListeners();
+    }
   }
 
   // 7. NOVO MÉTODO: Buscar o histórico de partidas


### PR DESCRIPTION
## Summary
- fetch user emotes from `/users/me/emotes` through the user service and provider state
- add an emote button to the battle arena that opens a picker with the player’s unlocked emotes
- send selected emotes via the socket service

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b02317a4483308b47f1854e45fc34)